### PR TITLE
Add demo link and login credentials to MRO case study

### DIFF
--- a/app/ai-journey/page.tsx
+++ b/app/ai-journey/page.tsx
@@ -745,19 +745,38 @@ export default function AIJourneyPage() {
               </div>
             </div>
             <div className="flex-1 bg-[#1C1C1C]">
-              {activeEmbedView === "figma" || !activeEmbedStory.videoUrl ? (
-                <iframe
-                  src={activeEmbedStory.embedUrl}
-                  title={`${activeEmbedStory.title} prototype`}
-                  className="h-[70vh] w-full border-0"
-                  allowFullScreen
-                />
-              ) : (
+              {activeEmbedView === "video" && activeEmbedStory.videoUrl ? (
                 <iframe
                   src={activeEmbedStory.videoUrl}
                   title={`${activeEmbedStory.title} overview video`}
                   className="h-[70vh] w-full border-0"
                   allow="autoplay; fullscreen"
+                  allowFullScreen
+                />
+              ) : activeEmbedView === "demo" && activeEmbedStory.demoUrl ? (
+                <div className="flex h-full flex-col items-center justify-center gap-4 px-6 text-center text-white">
+                  <p className="text-lg font-light text-white">
+                    Open the demo in a new tab to explore the Maintenance, Repair, and Operations experience.
+                  </p>
+                  <a
+                    href={activeEmbedStory.demoUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="rounded-full border border-white px-6 py-3 text-sm font-medium uppercase tracking-wide text-white transition-colors hover:bg-white hover:text-[#FF462D]"
+                  >
+                    Launch Demo
+                  </a>
+                  {demoCredentials && (
+                    <div className="rounded-md border border-white/60 bg-white/10 px-4 py-3 text-sm">
+                      Login: <span className="font-semibold">{demoCredentials.username}</span> / {demoCredentials.password}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <iframe
+                  src={activeEmbedStory.embedUrl}
+                  title={`${activeEmbedStory.title} prototype`}
+                  className="h-[70vh] w-full border-0"
                   allowFullScreen
                 />
               )}

--- a/app/ai-journey/page.tsx
+++ b/app/ai-journey/page.tsx
@@ -47,8 +47,13 @@ export default function AIJourneyPage() {
     }
 
     const embedStory = { ...story, ...overrides }
+    const hasVideo = Boolean(embedStory.videoUrl)
+    const hasEmbed = Boolean(embedStory.embedUrl)
+    const hasDemoLink = Boolean(embedStory.demoUrl)
+    const initialView = hasVideo ? "video" : hasEmbed ? "figma" : hasDemoLink ? "demo" : "figma"
+
     setActiveEmbedStory(embedStory)
-    setActiveEmbedView(embedStory.videoUrl ? "video" : "figma")
+    setActiveEmbedView(initialView)
   }
 
   const customerStories = [

--- a/app/ai-journey/page.tsx
+++ b/app/ai-journey/page.tsx
@@ -95,6 +95,11 @@ export default function AIJourneyPage() {
       aiFeature: "Automation",
       embedUrl: maintenanceOperationsEmbedUrl,
       externalUrl: maintenanceOperationsPrototypeUrl,
+      demoUrl: maintenanceOperationsDemoUrl,
+      demoCredentials: {
+        username: "admin",
+        password: "admin123",
+      },
     },
     {
       id: 2,

--- a/app/ai-journey/page.tsx
+++ b/app/ai-journey/page.tsx
@@ -13,7 +13,7 @@ export default function AIJourneyPage() {
   const [isFeatureModalOpen, setIsFeatureModalOpen] = useState(false)
   const [selectedStory, setSelectedStory] = useState(null)
   const [activeEmbedStory, setActiveEmbedStory] = useState(null)
-  const [activeEmbedView, setActiveEmbedView] = useState<"video" | "figma">("video")
+  const [activeEmbedView, setActiveEmbedView] = useState<"video" | "figma" | "demo">("video")
   const [searchTerm, setSearchTerm] = useState("")
   const [currentPage, setCurrentPage] = useState(1)
   const [isVideoLibraryOpen, setIsVideoLibraryOpen] = useState(false)

--- a/app/ai-journey/page.tsx
+++ b/app/ai-journey/page.tsx
@@ -29,6 +29,8 @@ export default function AIJourneyPage() {
       activeEmbedStory?.demoUrl,
   )
   const demoCredentials = activeEmbedStory?.demoCredentials
+  const isViewDemoActive =
+    activeEmbedView === "figma" || (!activeEmbedStory?.embedUrl && activeEmbedView === "demo")
 
   const connectedTravelerPrototypeUrl =
     "https://www.figma.com/proto/SOJfxIoop1uPyLkAYrd19D/Kyndryl-Connected-Traveller--New-Version?page-id=170%3A2293&node-id=2014-11654&viewport=3245%2C-460%2C0.13&t=JtIjOc4RmPuhg9dW-1&scaling=scale-down&content-scaling=fixed&starting-point-node-id=2014%3A9590"

--- a/app/ai-journey/page.tsx
+++ b/app/ai-journey/page.tsx
@@ -681,7 +681,12 @@ export default function AIJourneyPage() {
                 <p className="text-sm font-medium text-[#FF462D]">{activeEmbedStory.alliance}</p>
                 <h2 className="text-2xl font-light text-[#3D3C3C]">{activeEmbedStory.title}</h2>
               </div>
-              <div className="flex items-center gap-3">
+              <div className="flex flex-wrap items-center justify-end gap-3">
+                {demoCredentials && (
+                  <div className="rounded-md border border-gray-300 bg-white px-3 py-2 text-xs font-medium text-[#3D3C3C]">
+                    Login: <span className="font-semibold">{demoCredentials.username}</span> / {demoCredentials.password}
+                  </div>
+                )}
                 {(hasActiveVideo || hasActiveDemo) && (
                   <div className="flex items-center gap-2 rounded-full border border-gray-300 bg-white p-1">
                     {hasActiveVideo && (
@@ -701,13 +706,20 @@ export default function AIJourneyPage() {
                     {hasActiveDemo && (
                       <button
                         type="button"
-                        onClick={() => setActiveEmbedView("figma")}
+                        onClick={() => {
+                          if (typeof window !== "undefined" && activeEmbedStory?.demoUrl) {
+                            window.open(activeEmbedStory.demoUrl, "_blank", "noopener,noreferrer")
+                          }
+                          if (activeEmbedStory?.embedUrl) {
+                            setActiveEmbedView("figma")
+                          } else {
+                            setActiveEmbedView("demo")
+                          }
+                        }}
                         className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
-                          activeEmbedView === "figma"
-                            ? "bg-[#FF462D] text-white shadow-sm"
-                            : "text-[#3D3C3C] hover:bg-[#F2F1EE]"
+                          isViewDemoActive ? "bg-[#FF462D] text-white shadow-sm" : "text-[#3D3C3C] hover:bg-[#F2F1EE]"
                         }`}
-                        aria-pressed={activeEmbedView === "figma"}
+                        aria-pressed={isViewDemoActive}
                       >
                         View Demo
                       </button>
@@ -715,7 +727,7 @@ export default function AIJourneyPage() {
                   </div>
                 )}
                 <a
-                  href={activeEmbedStory.externalUrl || activeEmbedStory.embedUrl}
+                  href={activeEmbedStory.externalUrl || activeEmbedStory.embedUrl || activeEmbedStory.demoUrl}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="rounded-full border border-[#FF462D] px-4 py-2 text-sm font-medium text-[#FF462D] transition-colors hover:bg-[#FF462D] hover:text-white"

--- a/app/ai-journey/page.tsx
+++ b/app/ai-journey/page.tsx
@@ -25,8 +25,10 @@ export default function AIJourneyPage() {
 
   const hasActiveVideo = Boolean(activeEmbedStory?.videoUrl)
   const hasActiveDemo = Boolean(
-    activeEmbedStory?.embedUrl && (!hasActiveVideo || activeEmbedStory.embedUrl !== activeEmbedStory.videoUrl),
+    (activeEmbedStory?.embedUrl && (!hasActiveVideo || activeEmbedStory.embedUrl !== activeEmbedStory.videoUrl)) ||
+      activeEmbedStory?.demoUrl,
   )
+  const demoCredentials = activeEmbedStory?.demoCredentials
 
   const connectedTravelerPrototypeUrl =
     "https://www.figma.com/proto/SOJfxIoop1uPyLkAYrd19D/Kyndryl-Connected-Traveller--New-Version?page-id=170%3A2293&node-id=2014-11654&viewport=3245%2C-460%2C0.13&t=JtIjOc4RmPuhg9dW-1&scaling=scale-down&content-scaling=fixed&starting-point-node-id=2014%3A9590"

--- a/app/ai-journey/page.tsx
+++ b/app/ai-journey/page.tsx
@@ -39,6 +39,7 @@ export default function AIJourneyPage() {
   const maintenanceOperationsEmbedUrl = `https://www.figma.com/embed?embed_host=share&url=${encodeURIComponent(
     maintenanceOperationsPrototypeUrl,
   )}`
+  const maintenanceOperationsDemoUrl = "https://aeromonitor.apps-aws.com/login"
 
   const openEmbedModalForStory = (story, overrides = {}) => {
     if (!story) {

--- a/app/ai-journey/page.tsx
+++ b/app/ai-journey/page.tsx
@@ -710,11 +710,11 @@ export default function AIJourneyPage() {
                           if (typeof window !== "undefined" && activeEmbedStory?.demoUrl) {
                             window.open(activeEmbedStory.demoUrl, "_blank", "noopener,noreferrer")
                           }
-                          if (activeEmbedStory?.embedUrl) {
-                            setActiveEmbedView("figma")
-                          } else {
+                          if (activeEmbedStory?.demoUrl) {
                             setActiveEmbedView("demo")
+                            return
                           }
+                          setActiveEmbedView("figma")
                         }}
                         className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
                           isViewDemoActive ? "bg-[#FF462D] text-white shadow-sm" : "text-[#3D3C3C] hover:bg-[#F2F1EE]"

--- a/app/ai-journey/page.tsx
+++ b/app/ai-journey/page.tsx
@@ -30,7 +30,7 @@ export default function AIJourneyPage() {
   )
   const demoCredentials = activeEmbedStory?.demoCredentials
   const isViewDemoActive =
-    activeEmbedView === "figma" || (!activeEmbedStory?.embedUrl && activeEmbedView === "demo")
+    activeEmbedView === "figma" || (activeEmbedStory?.demoUrl && activeEmbedView === "demo")
 
   const connectedTravelerPrototypeUrl =
     "https://www.figma.com/proto/SOJfxIoop1uPyLkAYrd19D/Kyndryl-Connected-Traveller--New-Version?page-id=170%3A2293&node-id=2014-11654&viewport=3245%2C-460%2C0.13&t=JtIjOc4RmPuhg9dW-1&scaling=scale-down&content-scaling=fixed&starting-point-node-id=2014%3A9590"


### PR DESCRIPTION
## Purpose

Update the Maintenance, Repair, and Operations (MRO) case study to include a live demo link with login credentials. The user requested linking the "View Demo" button to https://aeromonitor.apps-aws.com/login and displaying the login credentials (admin / admin123) in the modal header for easy access.

## Code changes

- Added `demoUrl` property to the MRO case study pointing to the AeroMonitor demo
- Added `demoCredentials` object with username and password for the demo
- Enhanced the embed view state management to support a new "demo" view type
- Updated the "View Demo" button to open the demo URL in a new tab when available
- Added login credentials display in the modal header when demo credentials exist
- Created a dedicated demo view that shows launch instructions and credentials
- Updated the logic for determining which view to show based on available content types (video, figma embed, or demo link)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2ee132f89a31423589189c68e78d242c/quantum-zone)

👀 [Preview Link](https://2ee132f89a31423589189c68e78d242c-quantum-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2ee132f89a31423589189c68e78d242c</projectId>-->
<!--<branchName>quantum-zone</branchName>-->